### PR TITLE
[ALS-5535] Implement route restriction and remove API display functio…

### DIFF
--- a/ui/src/main/picsureui/overrides/router.js
+++ b/ui/src/main/picsureui/overrides/router.js
@@ -7,6 +7,8 @@ define(["backbone", "underscore", "handlebars", "studyAccess/studyAccess", "picS
               outputPanel, queryBuilder, searchHelpTooltipTemplate, output,
               FilterListView, SearchView, ToolSuiteView, queryResultsView,
               ApiPanelView, filterModel, tagFilterModel, landingView, session) {
+        const allowedRoutes = ["dataAccess", "openAccess", "queryBuilder", "not_authorized", "unexpected_error"]
+
         let createUserSession = function (that, callback, args) {
             let uuid = localStorage.getItem('OPEN_ACCESS_UUID');
             if (uuid) {
@@ -41,6 +43,13 @@ define(["backbone", "underscore", "handlebars", "studyAccess/studyAccess", "picS
 
         let execute = function (callback, args, name) {
             let deferred = $.Deferred();
+
+            // check if the route is allowed
+            if (!allowedRoutes.includes(callback?.name?.split('/')[1])) {
+                // redirect the user to the landing page
+                callback = this.defaultAction;
+            }
+
             if (!session.isValid(deferred)) {
                 createUserSession(this, callback, args);
             } else {
@@ -113,16 +122,6 @@ define(["backbone", "underscore", "handlebars", "studyAccess/studyAccess", "picS
             filterListView.render();
         };
 
-        let displayAPI = function () {
-            $(".header-btn.active").removeClass('active');
-            $(".header-btn[data-href='/picsureui/api']").addClass('active');
-            $('#main-content').empty();
-
-            var apiPanelView = new ApiPanelView({});
-            $('#main-content').append(apiPanelView.$el);
-            apiPanelView.render();
-        };
-
         return {
             routes: {
                 /**
@@ -132,9 +131,6 @@ define(["backbone", "underscore", "handlebars", "studyAccess/studyAccess", "picS
                  * Ex:
                  * "picsureui/queryBuilder2" : function() { renderQueryBuilder2(); }
                  */
-                "psamaui/login(/)": undefined,
-                "picsureui/login(/)": undefined,
-                "psamaui/logout(/)": undefined,
                 "picsureui/dataAccess": displayDataAccess,
                 "picsureui/openAccess": function () {
                     displayOpenAccess.call(this);
@@ -142,7 +138,6 @@ define(["backbone", "underscore", "handlebars", "studyAccess/studyAccess", "picS
                 "picsureui/queryBuilder(/)": function () {
                     displayOpenAccess.call(this);
                 },
-                "picsureui/api": displayAPI,
                 "picsureui(/)": displayLandingPage,
             },
             defaultAction: displayLandingPage,


### PR DESCRIPTION
* [ALS-5535] Implement route restriction and remove API display function

Added a list of allowed routes in the frontend application and implemented a check to ensure only valid routes are accessed. If invalid, the user is redirected to the landing page. The function for displaying API has also been removed from router.js.