### PR TITLE
auto re-authentication fix

### DIFF
--- a/ui/src/main/picsureui/middleware/reauthenticate.js
+++ b/ui/src/main/picsureui/middleware/reauthenticate.js
@@ -16,6 +16,10 @@ define(["backbone", "common/session"], function (Backbone, session) {
     return Backbone.View.extend({
         initialize: function () {
             $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+                if (options.url.startsWith("/psamaui")) {
+                    return;
+                }
+
                 // Check if the token is expired
                 if (expired() || expireSoon()) {
                     // We will re-authenticate the user
@@ -28,7 +32,7 @@ define(["backbone", "common/session"], function (Backbone, session) {
                             data: JSON.stringify({uuid: uuid}),
                             success: function (data) {
                                 // Update the session
-                                session.init(data);
+                                session.sessionInit(data);
                             },
                             error: function (data) {
                                 // handle error

--- a/ui/src/main/picsureui/middleware/reauthenticate.js
+++ b/ui/src/main/picsureui/middleware/reauthenticate.js
@@ -1,0 +1,50 @@
+define(["backbone", "common/session"], function (Backbone, session) {
+    // Create a middleware that first checks if the session is expired or will expire soon (2 minutes)
+    // If the session is going to expire soon or the session is expired, refresh the user's session by re-authenticating them
+    let expired = function (marginOfError = 0) {
+        if (sessionStorage.session) {
+            return new Date().getTime() / 1000 > JSON.parse(atob(JSON.parse(sessionStorage.session).token.split('.')[1])).exp - marginOfError;
+        }
+        //no session -> no token --> session has expired or does not exist.
+        return true;
+    };
+
+    let expireSoon = function () {
+        return expired(120);
+    };
+
+    return Backbone.View.extend({
+        initialize: function () {
+            $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+                // Check if the token is expired
+                if (expired() || expireSoon()) {
+                    // We will re-authenticate the user
+                    let uuid = JSON.parse(localStorage.getItem('OPEN_ACCESS_UUID'));
+                    if (uuid) {
+                        $.ajax({
+                            url: '/psamaui/reauthenticate',
+                            type: 'POST',
+                            contentType: 'application/json',
+                            data: JSON.stringify({uuid: uuid}),
+                            success: function (data) {
+                                // Update the session
+                                session.init(data);
+                            },
+                            error: function (data) {
+                                // handle error
+                                console.log(data);
+                            }
+                        });
+                    }
+                }
+
+                // set the authorization header for the request.
+                // This is because the session was updated, but the request was made before the session was updated
+                jqXHR.setRequestHeader("Authorization", "Bearer " + JSON.parse(sessionStorage.session).token);
+            });
+        },
+        render: function () {
+            return this;
+        }
+    });
+})

--- a/ui/src/main/picsureui/overrides/footer.js
+++ b/ui/src/main/picsureui/overrides/footer.js
@@ -1,0 +1,52 @@
+define(["handlebars",
+        "text!overrides/footer.hbs",
+        "common/modal",
+        "common/session",
+        "common/pic-sure-dialog-view",
+        "middleware/middleware",
+        "common/redirect-modal",
+        "middleware/reauthenticate",
+    ],
+    function (HBS, template, modal, session, dialog, Middleware, redirectModal, Reauthenticate) {
+        return {
+            /*
+             * The render function for the footer can be overridden here.
+             */
+            render: function () {
+                new Reauthenticate();
+                new Middleware();
+
+                let title = window.location.pathname.split("/");
+                title = title[2]; // begins with empty string
+                switch (title) {
+                    case "dataAccess":
+                        title = "Data Access";
+                        break;
+                    case "openAccess":
+                        title = "Open Access";
+                        break;
+                    case "queryBuilder":
+                        title = "Authorized Builder";
+                        break;
+                    default:
+                        title = "";
+                        break;
+                }
+                title = "BioData Catalyst Powered by PIC-SURE: " + title;
+                if (!$('title').length) {
+                    $('head').append("<title></title>");
+                }
+                $('title').html(title);
+                this.$el.html(HBS.compile(template)());
+
+                let redirect = new redirectModal();
+
+                // Using .off() to prevent multiple event handlers from being attached
+                $(document).off('click', 'a[target="_blank"]').on('click', 'a[target="_blank"]', function (event) {
+                    event.preventDefault();
+
+                    redirect.render(event);
+                });
+            }
+        };
+    });

--- a/ui/src/main/picsureui/overrides/session.js
+++ b/ui/src/main/picsureui/overrides/session.js
@@ -20,14 +20,9 @@ define(["picSure/tokenFunctions"],
                 sessionStorage.setItem("session", JSON.stringify(currentSession));
             },
             handleNotAuthorizedResponse: function () {
-                try {
-                    // A token should never be expired and the user should never not be authorized.
-                    // If the token has expired, there is like an issue with PSAMA.
-                    window.location = '/psamaui/not_authorized/';
-                } catch (e) {
-                    console.log("Error determining token expiry");
-                    history.pushState({}, "", "/psamaui/not_authorized");
-                }
+                // if the session has expired we will clear the session and reload the page
+                sessionStorage.clear();
+                window.location.reload();
             }
         };
     });


### PR DESCRIPTION
- Add a new middleware that is used to re-authenticate users when a token is expired or expiring. The middleware does the following: 
1. Checks if the path is not psama or psamaui
2. Checks if token is expired or expiring
3. Starts the processes of reauthenicating a user and sets a flag to be used by future ajax request
4. Queues all ajax request while the user gets a new access token
5. When the re-authentication is complete it will processes the queue of ajax request

I opted to due this via the UI instead of the PSAMA application. I think it will take a larger lift and more investigation to accomplish this functionality on the server.