### PR TITLE
[ALS-6103] Changed URL for Ajax request in router.js

### DIFF
--- a/ui/src/main/picsureui/overrides/router.js
+++ b/ui/src/main/picsureui/overrides/router.js
@@ -16,7 +16,7 @@ define(["backbone", "underscore", "handlebars", "studyAccess/studyAccess", "picS
             }
 
             $.ajax({
-                url: '/psama/open/authentication',
+                url: '/psama/authentication/open',
                 type: 'POST',
                 data: JSON.stringify({
                     UUID: uuid


### PR DESCRIPTION
The URL for the Ajax request in the router.js file has been updated. It has been changed from '/psama/open/authentication' to '/psama/authentication/open'.